### PR TITLE
introduce screen orientation constants

### DIFF
--- a/src/js/components/deviceRotate/controller.js
+++ b/src/js/components/deviceRotate/controller.js
@@ -42,20 +42,20 @@ class ComponentsDeviceRotateController extends ComponentsBaseController {
   }
 
   get _showOnLandscape() {
-    return !this._resolutionsConfig.find(resolution => resolution.orientation === 'landscape');
+    return !this._resolutionsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.LANDSCAPE);
   }
 
   get _showOnPortrait() {
-    return !this._resolutionsConfig.find(resolution => resolution.orientation === 'portrait');
+    return !this._resolutionsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.PORTRAIT);
   }
 
   get _isPortrait() {
-    return this._orientation === 'portrait';
+    return this._orientation === Urso.device.ScreenOrientation.PORTRAIT;
   }
 
   get _needShow() {
-    return (this._orientation === 'portrait' && this._showOnPortrait) ||
-      (this._orientation !== 'portrait' && this._showOnLandscape)
+    return (this._orientation === Urso.device.ScreenOrientation.PORTRAIT && this._showOnPortrait) ||
+      (this._orientation !== Urso.device.ScreenOrientation.PORTRAIT && this._showOnLandscape)
   }
 
   set _isVisible(needShowDiv) {
@@ -63,7 +63,7 @@ class ComponentsDeviceRotateController extends ComponentsBaseController {
   }
 
   _updateOrientation() {
-    this._orientation = innerWidth > innerHeight ? 'landscape' : 'portrait';
+    this._orientation = innerWidth > innerHeight ? Urso.device.ScreenOrientation.LANDSCAPE : Urso.device.ScreenOrientation.PORTRAIT;
   }
 
   _updateVisibility() {

--- a/src/js/components/fullscreen/android.js
+++ b/src/js/components/fullscreen/android.js
@@ -33,7 +33,7 @@ class ComponentsFullscreenAndroid {
   }
 
   _updateOrientation() {
-    this._orientation = innerWidth > innerHeight ? 'landscape' : 'portrait';
+    this._orientation = innerWidth > innerHeight ? Urso.device.ScreenOrientation.LANDSCAPE : Urso.device.ScreenOrientation.PORTRAIT;
   }
 
   get isFullscreen() {
@@ -49,7 +49,7 @@ class ComponentsFullscreenAndroid {
   }
 
   get _isPortrait() {
-    return this._orientation === 'portrait';
+    return this._orientation === Urso.device.ScreenOrientation.PORTRAIT;
   }
 
   get _needShowOnCurrentOrientation() {
@@ -58,11 +58,11 @@ class ComponentsFullscreenAndroid {
   }
 
   get _showOnLandscape() {
-    return this._orientationsConfig.find(resolution => resolution.orientation === 'landscape');
+    return this._orientationsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.LANDSCAPE);
   }
 
   get _showOnPortrait() {
-    return this._orientationsConfig.find(resolution => resolution.orientation === 'portrait');
+    return this._orientationsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.PORTRAIT);
   }
 
   set isVisible(needShowDiv) {

--- a/src/js/components/fullscreen/controller.js
+++ b/src/js/components/fullscreen/controller.js
@@ -37,15 +37,15 @@ class ComponentsFullscreenController extends ComponentsBaseController {
   }
 
   get _showOnLandscape() {
-    return this._resolutionsConfig.find(resolution => resolution.orientation === 'landscape');
+    return this._resolutionsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.LANDSCAPE);
   }
 
   get _showOnPortrait() {
-    return this._resolutionsConfig.find(resolution => resolution.orientation === 'portrait');
+    return this._resolutionsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.PORTRAIT);
   }
 
   get _isPortrait() {
-    return innerWidth > innerHeight ? 'portrait' : 'landscape';
+    return innerWidth > innerHeight ? Urso.device.ScreenOrientation.PORTRAIT : Urso.device.ScreenOrientation.LANDSCAPE;
   }
 
   get isFullscreen() {

--- a/src/js/components/fullscreen/ios.js
+++ b/src/js/components/fullscreen/ios.js
@@ -55,7 +55,7 @@ class ComponentsFullscreenIos {
   }
 
   _updateOrientation() {
-    this._orientation = innerWidth > innerHeight ? 'landscape' : 'portrait';
+    this._orientation = innerWidth > innerHeight ? Urso.device.ScreenOrientation.LANDSCAPE : Urso.device.ScreenOrientation.PORTRAIT;
   }
 
   _updateResize() {
@@ -68,7 +68,7 @@ class ComponentsFullscreenIos {
   }
 
   get _isPortrait() {
-    return this._orientation === 'portrait';
+    return this._orientation === Urso.device.ScreenOrientation.PORTRAIT;
   }
 
   get _needShowOnCurrentOrientation() {
@@ -76,11 +76,11 @@ class ComponentsFullscreenIos {
   }
 
   get _showOnLandscape() {
-    return this._orientationsConfig.find(resolution => resolution.orientation === 'landscape');
+    return this._orientationsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.LANDSCAPE);
   }
 
   get _showOnPortrait() {
-    return this._orientationsConfig.find(resolution => resolution.orientation === 'portrait');
+    return this._orientationsConfig.find(resolution => resolution.orientation === Urso.device.ScreenOrientation.PORTRAIT);
   }
 
   set isVisible(needShowDiv) {

--- a/src/js/lib/device.js
+++ b/src/js/lib/device.js
@@ -476,6 +476,16 @@ LibDevice = function () {
     */
     this.fullscreenKeyboard = false;
 
+    /**
+    * Enum for possible screen orientations.
+    * @readonly
+    * @enum {string}
+    */
+    this.ScreenOrientation = {
+        LANDSCAPE: 'landscape',
+        PORTRAIT: 'portrait'
+    };
+
 };
 
 // Device is really a singleton/static entity; instantiate it

--- a/src/js/modules/scenes/resolutions.js
+++ b/src/js/modules/scenes/resolutions.js
@@ -4,7 +4,6 @@ class ModulesScenesResolutions {
         this.singleton = true;
         this._activeResolution = false; //object
         this._templateSize = { orientation: 0, width: 0, height: 0 };
-        this._orientations = { landscape: 'landscape', portrait: 'portrait' }
         this._currentOrientation = null;
 
         this.refreshSceneSize = this.refreshSceneSize.bind(this);
@@ -53,7 +52,7 @@ class ModulesScenesResolutions {
         console.log('[SCENE] New Template Size', this._templateSize);
 
         //update InstancesModes
-        Object.values(this._orientations).forEach((orientationValue) => Urso.removeInstancesMode(orientationValue + 'Orientation'));
+        Object.values(Urso.device.ScreenOrientation).forEach((orientationValue) => Urso.removeInstancesMode(orientationValue + 'Orientation'));
         Urso.addInstancesMode(orientation + 'Orientation');
 
         //send new resolution event
@@ -85,7 +84,7 @@ class ModulesScenesResolutions {
     }
 
     _getOrientation(windowSize) {
-        return windowSize.width > windowSize.height ? this._orientations.landscape : this._orientations.portrait;  //todo move to constants
+        return windowSize.width > windowSize.height ? Urso.device.ScreenOrientation.LANDSCAPE : Urso.device.ScreenOrientation.PORTRAIT;
     }
 
     _getResolutionConfig(windowSize) {

--- a/src/js/modules/scenes/resolutionsConfig.js
+++ b/src/js/modules/scenes/resolutionsConfig.js
@@ -2,14 +2,14 @@ class ModulesScenesResolutionsConfig {
     constructor() {
         this.singleton = true;
 
-        this._orientations = ['landscape', 'portrait'];
+        this._orientations = Urso.device.ScreenOrientation;
 
         this.contents = [
             {
                 "name": 'default',
                 "width": 1920,
                 "height": 1080,
-                "orientation": 'landscape',
+                "orientation": Urso.device.ScreenOrientation.LANDSCAPE,
                 "adaptive": true
             }
         ];


### PR DESCRIPTION
### What:
Add `ScreenOrientation` enum to `LibDevice`.
Replace hardcoded strings for screen orientation with proper constants.